### PR TITLE
Bugfix/default sensor has bad header

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,10 @@
 Change history
 ==============
 
-
+1.1.2
+-----
+- Fix bug in HttpRequestor in which it could send a malformed HTTP header when
+  the requestor's bound HttpOptions had no auth scheme specified
 
 1.1.1
 -----

--- a/caliper/__init__.py
+++ b/caliper/__init__.py
@@ -33,8 +33,8 @@ install_aliases()
 from builtins import *
 
 __title__ = 'imsglobal_caliper'
-__version__ = '1.1.1'
-__build__ = 0x010201
+__version__ = '1.1.2'
+__build__ = 0x010202
 __author__ = 'IMS Global Learning Consortium, Inc.'
 __license__ = 'LGPLv3'
 

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -263,7 +263,7 @@ class Options(object):
 class HttpOptions(Options):
     def __init__(
             self,
-            api_key='CaliperKey',
+            api_key='',
             auth_scheme='',
             connection_request_timeout=10000,
             connection_timeout=10000,

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -281,7 +281,10 @@ class HttpOptions(Options):
         self.SOCKET_TIMEOUT = socket_timeout
 
     def get_auth_header_value(self):
-        return '{0} {1}'.format(self.AUTH_SCHEME, self.API_KEY)
+        if self.AUTH_SCHEME:
+            return '{0} {1}'.format(self.AUTH_SCHEME, self.API_KEY)
+        else:
+            return None
 
 
 ### Caliper serializable base class for all caliper objects that need serialization ###

--- a/caliper/request.py
+++ b/caliper/request.py
@@ -145,13 +145,10 @@ class HttpRequestor(EventStoreRequestor):
                 described_objects=described_objects,
                 optimize=self._options.OPTIMIZE_SERIALIZATION,
                 sensor_id=sensor_id)
-            r = s.post(
-                self._options.HOST,
-                data=payload['data'],
-                headers={
-                    'Authorization': self._options.get_auth_header_value(),
-                    'Content-Type': payload['type']
-                })
+            hdrs = {'Content-Type': payload['type']}
+            if self._options.get_auth_header_value():
+                hdrs.update({'Authorization': self._options.get_auth_header_value()})
+            r = s.post(self._options.HOST, data=payload['data'], headers=hdrs)
             if ((r.status_code is requests.codes.ok) or (r.status_code is requests.codes.created)):
                 v = True
                 identifiers += ids


### PR DESCRIPTION
The package's factory method to build a default sensor makes one that fashion's bad Auth headers. This PR fixes sensors so that they'll only send Auth headers when the sensor has a config that sets an auth scheme (like `Bearer`).