### PR TITLE
Stricter URI validation

### DIFF
--- a/caliper/base.py
+++ b/caliper/base.py
@@ -109,7 +109,7 @@ def is_valid_URI(uri):
     if not uri:
         return False
     elif (isinstance(uri, str) and (urllib_urlparse(uri).geturl() == uri)
-          and rfc3986_is_valid_uri(uri)):
+          and rfc3986_is_valid_uri(uri, require_scheme=True)):
         return True
     else:
         return False
@@ -387,9 +387,13 @@ class CaliperSerializable(object):
         if isinstance(v, BaseEntity) and t and not (is_subtype(v.type, t)):
             raise_with_traceback(
                 TypeError('Provided property is not of required type: {}'.format(t)))
-        if isinstance(v, str) and t and not is_subtype(t, CaliperSerializable):
-            raise_with_traceback(
-                ValueError('URI IDs can only be provided for objects of known Caliper types'))
+        if isinstance(v, str):
+            if not is_valid_URI(v):
+                raise_with_traceback(
+                    ValueError('ID value for object property must be valid URI: {}'.format(v)))
+            if t and not is_subtype(t, CaliperSerializable):
+                raise_with_traceback(
+                    ValueError('URI IDs can only be provided for objects of known Caliper types'))
         self._update_props(k, v)
 
     def _set_time_prop(self, k, v, req=False):


### PR DESCRIPTION
- RFC3986 allows for insistence that a scheme be present in a valid URI; use
  that keyword param for validation

- Adding an object property when building a CaliperSerializable now checks
  that, if you pass a string instead of an object for a property, ensure the
  string is a valid URI (as per Caliper requirement that a property in a
  Caliper thing that is itself a Caliper thing can either be that inlined
  property, or it can be the @id for that property).