### PR TITLE
Provide more strict support for Caliper datetime values (iss181)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,8 @@
 
   *1.1.10.5*. Bug fix for [Issue #176](https://github.com/IMSGlobal/caliper-python/issues/176).
 
+  *1.1.10.6*. Bug fix for [Issue #181](https://github.com/IMSGlobal/caliper-python/issues/181).
+
 
 ## 1.1.9
 

--- a/caliper/__init__.py
+++ b/caliper/__init__.py
@@ -33,8 +33,8 @@ install_aliases()
 from builtins import *
 
 __title__ = 'imsglobal_caliper'
-__version__ = '1.1.10.5'
-__build__ = 0x01011005
+__version__ = '1.1.10.6'
+__build__ = 0x01011006
 __author__ = 'IMS Global Learning Consortium, Inc.'
 __license__ = 'LGPLv3'
 

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -43,13 +43,13 @@ from caliper.constants import (CALIPER_CLASSES, CALIPER_CORE_CONTEXT, CALIPER_CO
 
 _uri_validator = rfc3986_validators.Validator().require_presence_of('scheme', )
 
-_time_re = re.compile(r'\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(YYYY='([0-9]{4})',
-                                                                           MM='([0-9]{2})',
-                                                                           DD='([0-9]{2})',
-                                                                           HH='([0-9]{2})',
-                                                                           mm='([0-9]{2})',
-                                                                           ss='([0-9]{2})',
-                                                                           SSS='([0-9]{3})'))
+_datetime_re = re.compile(r'\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(YYYY='([0-9]{4})',
+                                                                               MM='([0-9]{2})',
+                                                                               DD='([0-9]{2})',
+                                                                               HH='([0-9]{2})',
+                                                                               mm='([0-9]{2})',
+                                                                               ss='([0-9]{2})',
+                                                                               SSS='([0-9]{3})'))
 
 
 def deprecation(m):
@@ -97,7 +97,7 @@ def _get_base_context(ctxt):
 
 def is_valid_datetime(dt):
     try:
-        assert (_time_re.match(dt))
+        assert (_datetime_re.match(dt))
         aniso_parse_datetime(dt)
         return True
     except Exception:

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -97,7 +97,7 @@ def _get_base_context(ctxt):
 
 def is_valid_datetime(dt):
     try:
-        assert (re.match(_time_re, dt))
+        assert (_time_re.match(dt))
         aniso_parse_datetime(dt)
         return True
     except Exception:

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -43,6 +43,14 @@ from caliper.constants import (CALIPER_CLASSES, CALIPER_CORE_CONTEXT, CALIPER_CO
 
 _uri_validator = rfc3986_validators.Validator().require_presence_of('scheme', )
 
+_time_re = re.compile(r'\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(YYYY='([0-9]{4})',
+                                                                           MM='([0-9]{2})',
+                                                                           DD='([0-9]{2})',
+                                                                           HH='([0-9]{2})',
+                                                                           mm='([0-9]{2})',
+                                                                           ss='([0-9]{2})',
+                                                                           SSS='([0-9]{3})'))
+
 
 def deprecation(m):
     warnings.warn(m, DeprecationWarning, stacklevel=2)
@@ -88,14 +96,6 @@ def _get_base_context(ctxt):
 
 
 def is_valid_datetime(dt):
-    _time_re = r'\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(
-        YYYY='([0-9]{4})',
-        MM='([0-9]{2})',
-        DD='([0-9]{2})',
-        HH='([0-9]{2})',
-        mm='([0-9]{2})',
-        ss='([0-9]{2})',
-        SSS='([0-9]{3})')
     try:
         assert (re.match(_time_re, dt))
         aniso_parse_datetime(dt)

--- a/caliper/base.py
+++ b/caliper/base.py
@@ -88,13 +88,14 @@ def _get_base_context(ctxt):
 
 
 def is_valid_datetime(dt):
-    _time_re = '\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(YYYY='([0-9]{4})',
-                                                                   MM='([0-9]{2})',
-                                                                   DD='([0-9]{2})',
-                                                                   HH='([0-9]{2})',
-                                                                   mm='([0-9]{2})',
-                                                                   ss='([0-9]{2})',
-                                                                   SSS='([0-9]{3})')
+    _time_re = r'\A{YYYY}-{MM}-{DD}T{HH}:{mm}:{ss}.{SSS}Z\Z'.format(
+        YYYY='([0-9]{4})',
+        MM='([0-9]{2})',
+        DD='([0-9]{2})',
+        HH='([0-9]{2})',
+        mm='([0-9]{2})',
+        ss='([0-9]{2})',
+        SSS='([0-9]{3})')
     try:
         assert (re.match(_time_re, dt))
         aniso_parse_datetime(dt)

--- a/caliper/condensor.py
+++ b/caliper/condensor.py
@@ -31,14 +31,14 @@ except ImportError:
 
 import copy, importlib
 
-from caliper.base import is_valid_context, is_valid_date, is_valid_URI, suggest_profile
+from caliper.base import is_valid_context, is_valid_datetime, is_valid_URI, suggest_profile
 from caliper.constants import (CALIPER_CLASSES, CALIPER_CORE_CONTEXT, CALIPER_PROFILES,
                                CALIPER_PROFILES_FOR_CONTEXTS)
 
 
 def from_caliper_envelope(d, strict=False):
     r = None
-    if (is_valid_URI(d.get('sensor')) and is_valid_date(d.get('sendTime'))
+    if (is_valid_URI(d.get('sensor')) and is_valid_datetime(d.get('sendTime'))
             and isinstance(d.get('data'), MutableSequence)):
         r = from_json_list(d.get('data'), strict=strict)
     return r

--- a/caliper/entities.py
+++ b/caliper/entities.py
@@ -54,8 +54,8 @@ class Entity(BaseEntity):
                  extensions=None):
         BaseEntity.__init__(self, context=context, profile=profile)
         self._set_id(id)
-        self._set_date_prop('dateCreated', dateCreated)
-        self._set_date_prop('dateModified', dateModified)
+        self._set_datetime_prop('dateCreated', dateCreated)
+        self._set_datetime_prop('dateModified', dateModified)
         self._set_str_prop('description', description)
         self._set_str_prop('name', name)
         self._set_obj_prop('extensions', extensions)
@@ -266,8 +266,8 @@ class AggregateMeasure(Entity, Generatable):
                  maxMetricValue=None,
                  **kwargs):
         Entity.__init__(self, **kwargs)
-        self._set_date_prop('endedAtTime', endedAtTime)
-        self._set_date_prop('startedAtTime', startedAtTime)
+        self._set_datetime_prop('endedAtTime', endedAtTime)
+        self._set_datetime_prop('startedAtTime', startedAtTime)
         self._set_float_prop('metricValue', metricValue, req=True)
         self._set_float_prop('maxMetricValue', maxMetricValue)
 
@@ -282,7 +282,7 @@ class AggregateMeasure(Entity, Generatable):
 
     @endedAtTime.setter
     def endedAtTime(self, new_time):
-        self._set_date_prop('endedAtTime', new_time)
+        self._set_datetime_prop('endedAtTime', new_time)
 
     @property
     def metric(self):
@@ -323,7 +323,7 @@ class DigitalResource(Entity, Generatable, Referrable, Targetable):
                             learningObjectives,
                             t=ENTITY_TYPES['LEARNING_OBJECTIVE'])
         self._set_list_prop('creators', creators, t=ENTITY_TYPES['AGENT'])
-        self._set_date_prop('datePublished', datePublished)
+        self._set_datetime_prop('datePublished', datePublished)
         self._set_obj_prop('isPartOf', isPartOf, t=ENTITY_TYPES['ENTITY'])
         self._set_list_prop('keywords', keywords, t=str)
         self._set_str_prop('mediaType', mediaType)
@@ -536,10 +536,10 @@ class AssignableDigitalResource(DigitalResource, Assignable):
                  maxScore=None,
                  **kwargs):
         DigitalResource.__init__(self, **kwargs)
-        self._set_date_prop('dateToActivate', dateToActivate)
-        self._set_date_prop('dateToShow', dateToShow)
-        self._set_date_prop('dateToStartOn', dateToStartOn)
-        self._set_date_prop('dateToSubmit', dateToSubmit)
+        self._set_datetime_prop('dateToActivate', dateToActivate)
+        self._set_datetime_prop('dateToShow', dateToShow)
+        self._set_datetime_prop('dateToStartOn', dateToStartOn)
+        self._set_datetime_prop('dateToSubmit', dateToSubmit)
         self._set_int_prop('maxAttempts', maxAttempts)
         self._set_int_prop('maxSubmits', maxSubmits)
         self._set_float_prop('maxScore', maxScore)
@@ -605,9 +605,9 @@ class Attempt(Entity, Generatable):
         self._set_obj_prop('assignee', assignee, t=ENTITY_TYPES['PERSON'])
         self._set_int_prop('count', count)
         self._set_duration_prop('duration', duration)
-        self._set_date_prop('endedAtTime', endedAtTime)
+        self._set_datetime_prop('endedAtTime', endedAtTime)
         self._set_obj_prop('isPartOf', isPartOf, t=ENTITY_TYPES['ATTEMPT'])
-        self._set_date_prop('startedAtTime', startedAtTime)
+        self._set_datetime_prop('startedAtTime', startedAtTime)
 
     @property
     def assignable(self):
@@ -635,7 +635,7 @@ class Attempt(Entity, Generatable):
 
     @endedAtTime.setter
     def endedAtTime(self, new_time):
-        self._set_date_prop('endedAtTime', new_time)
+        self._set_datetime_prop('endedAtTime', new_time)
 
     @property
     def isPartOf(self):
@@ -656,8 +656,8 @@ class Response(Entity, Generatable):
         Entity.__init__(self, **kwargs)
         self._set_obj_prop('attempt', attempt, t=ENTITY_TYPES['ATTEMPT'])
         self._set_duration_prop('duration', duration)
-        self._set_date_prop('endedAtTime', endedAtTime)
-        self._set_date_prop('startedAtTime', startedAtTime)
+        self._set_datetime_prop('endedAtTime', endedAtTime)
+        self._set_datetime_prop('startedAtTime', startedAtTime)
 
     @property
     def attempt(self):
@@ -677,7 +677,7 @@ class Response(Entity, Generatable):
 
     @endedAtTime.setter
     def endedAtTime(self, new_time):
-        self._set_date_prop('endedAtTime', new_time)
+        self._set_datetime_prop('endedAtTime', new_time)
 
     @property
     def startedAtTime(self):
@@ -687,7 +687,7 @@ class Response(Entity, Generatable):
 class DateTimeResponse(Response):
     def __init__(self, dateTimeSelected=None, **kwargs):
         Response.__init__(self, **kwargs)
-        self._set_date_prop('dateTimeSelected', dateTimeSelected)
+        self._set_datetime_prop('dateTimeSelected', dateTimeSelected)
 
     @property
     def dateTimeSelected(self):
@@ -877,9 +877,9 @@ class Question(DigitalResource):
 class DateTimeQuestion(Question):
     def __init__(self, maxDateTime=None, maxLabel=None, minDateTime=None, minLabel=None, **kwargs):
         Question.__init__(self, **kwargs)
-        self._set_date_prop('maxDateTime', maxDateTime)
+        self._set_datetime_prop('maxDateTime', maxDateTime)
         self._set_str_prop('maxLabel', maxLabel)
-        self._set_date_prop('minDateTime', minDateTime)
+        self._set_datetime_prop('minDateTime', minDateTime)
         self._set_str_prop('minLabel', minLabel)
 
     @property
@@ -1049,7 +1049,7 @@ class SurveyInvitation(DigitalResource):
         DigitalResource.__init__(self, **kwargs)
         self._set_obj_prop('rater', rater, t=ENTITY_TYPES['PERSON'])
         self._set_int_prop('sentCount', sentCount)
-        self._set_date_prop('sentDate', sentDate)
+        self._set_datetime_prop('sentDate', sentDate)
         self._set_obj_prop('survey', survey, t=ENTITY_TYPES['SURVEY'])
 
     @property
@@ -1296,8 +1296,8 @@ class Session(Entity, Generatable, Targetable):
     def __init__(self, duration=None, endedAtTime=None, startedAtTime=None, user=None, **kwargs):
         Entity.__init__(self, **kwargs)
         self._set_duration_prop('duration', duration)
-        self._set_date_prop('endedAtTime', endedAtTime)
-        self._set_date_prop('startedAtTime', startedAtTime)
+        self._set_datetime_prop('endedAtTime', endedAtTime)
+        self._set_datetime_prop('startedAtTime', startedAtTime)
         self._set_obj_prop('user', user, t=ENTITY_TYPES['PERSON'])
 
     @property
@@ -1314,7 +1314,7 @@ class Session(Entity, Generatable, Targetable):
 
     @endedAtTime.setter
     def endedAtTime(self, new_time):
-        self._set_date_prop('endedAtTime', new_time)
+        self._set_datetime_prop('endedAtTime', new_time)
 
     @property
     def startedAtTime(self):

--- a/caliper/request.py
+++ b/caliper/request.py
@@ -45,7 +45,7 @@ class Envelope(CaliperSerializable):
         CaliperSerializable.__init__(self)
         self._set_list_prop('data', data, t=CaliperSerializable, req=True)
         self._set_str_prop('dataVersion', dataVersion, req=True)
-        self._set_date_prop('sendTime', send_time, req=True)
+        self._set_datetime_prop('sendTime', send_time, req=True)
         self._set_str_prop('sensor', sensor_id, req=True)
 
     @property
@@ -70,7 +70,7 @@ class Envelope(CaliperSerializable):
 
     @sendTime.setter
     def sendTime(self, v):
-        self._set_date_prop('sendTime', v)
+        self._set_datetime_prop('sendTime', v)
 
     @property
     def sensor(self):


### PR DESCRIPTION
- Addresses [issue #181](https://github.com/IMSGlobal/caliper-python/issues/181)

- Caliper datetime values, in spec, must have the format `YYYY-MM-DDTHH:mm:ss.SSSZ` (that is, have
  millisecond precision to three digits, and the trailing `Z` UTC timezone qualifer, rather than a
  time offset.

- rename `is_valid_date()` to `is_valid_datetime()` and improve it to more strictly check the
  format of date-time strings by first checking against a very simple re string and then attempting
  to parse with aniso8601. The re string does not attempt to do any tricky validation of
  characters; it only checks for the right number of characters, in the proper positions, with the
  right separators.

- move away from using a `_set_date_prop()` method in favour of the more appropriately named
  `_set_datetime_prop()`; the new method does stricter value checking on its inputs.