### PR TITLE
Remove use of marker types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 - Add support for user-agent type information within SoftwareApplication
   entities, and add new optional `client` field in Session entities.
 
+- Simplify implementation by removing marker types, as not in the Caliper specification.
+
 
 ## 1.1.10
 

--- a/caliper/constants.py
+++ b/caliper/constants.py
@@ -148,29 +148,14 @@ EVENT_TYPES = {
 EVENT_CLASSES = { EVENT_TYPES[key]:'caliper.events.{}'.format(EVENT_TYPES[key])
                   for key in EVENT_TYPES.keys() }
 
-
-MARKER_TYPES = {
-    'ASSIGNABLE': 'Assignable',
-    'GENERATABLE': 'Generatable',
-    'REFERRABLE': 'Referrable',
-    'TARGETABLE': 'Targetable',
-}
-
-## map implementing Python classes onto event types
-MARKER_CLASSES = { MARKER_TYPES[key]:'caliper.entities.{}'.format(MARKER_TYPES[key])
-                   for key in MARKER_TYPES.keys() }
-
-
 CALIPER_TYPES = {}
 CALIPER_TYPES.update(ENTITY_TYPES)
 CALIPER_TYPES.update(EVENT_TYPES)
-CALIPER_TYPES.update(MARKER_TYPES)
 
 ## maps types to Python classnames
 CALIPER_CLASSES = {}
 CALIPER_CLASSES.update(ENTITY_CLASSES)
 CALIPER_CLASSES.update(EVENT_CLASSES)
-CALIPER_CLASSES.update(MARKER_CLASSES)
 
 ## maps Python classnames back to types
 CALIPER_TYPES_FOR_CLASSES = { CALIPER_CLASSES[key]:key for key in CALIPER_CLASSES.keys() }

--- a/caliper/entities.py
+++ b/caliper/entities.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     from collections import MutableSequence, MutableMapping
 
-from caliper.constants import ENTITY_TYPES, MARKER_TYPES
+from caliper.constants import ENTITY_TYPES
 from caliper.constants import CALIPER_LTI_MESSAGES, CALIPER_METRICS, CALIPER_ROLES, CALIPER_STATUS, CALIPER_SYSIDTYPES
 from caliper.base import CaliperSerializable, BaseEntity
 from caliper.base import ensure_type, ensure_list_type
@@ -128,23 +128,6 @@ class SystemIdentifier(BaseEntity):
         return self._get_prop('extensions')
 
 
-## Behavioural interfaces for entities ##
-class Assignable(BaseEntity):
-    pass
-
-
-class Generatable(BaseEntity):
-    pass
-
-
-class Referrable(BaseEntity):
-    pass
-
-
-class Targetable(BaseEntity):
-    pass
-
-
 ## Fundamental entities ##
 class Collection(Entity):
     def __init__(self, items=None, **kwargs):
@@ -199,7 +182,7 @@ class Membership(Entity):
 
 
 ## Agent entities
-class Agent(Entity, Referrable):
+class Agent(Entity):
     def __init__(self, **kwargs):
         Entity.__init__(self, **kwargs)
 
@@ -315,7 +298,7 @@ class LearningObjective(Entity):
 
 
 ## Aggregate measures
-class AggregateMeasure(Entity, Generatable):
+class AggregateMeasure(Entity):
     def __init__(self,
                  endedAtTime=None,
                  metric=None,
@@ -359,14 +342,14 @@ class AggregateMeasure(Entity, Generatable):
         return self._get_prop('maxMetricValue')
 
 
-class AggregateMeasureCollection(Collection, Generatable):
+class AggregateMeasureCollection(Collection):
     def __init__(self, items=None, **kwargs):
         Collection.__init__(self, **kwargs)
         self._set_list_prop('items', items, t=ENTITY_TYPES['AGGREGATE_MEASURE'])
 
 
 ## Creative works
-class DigitalResource(Entity, Generatable, Referrable, Targetable):
+class DigitalResource(Entity):
     def __init__(self,
                  learningObjectives=None,
                  creators=None,
@@ -432,7 +415,7 @@ class DigitalResourceCollection(DigitalResource, Collection):
         self._set_list_prop('items', items, t=ENTITY_TYPES['DIGITAL_RESOURCE'])
 
 
-class Frame(DigitalResource, Targetable):
+class Frame(DigitalResource):
     def __init__(self, index=None, **kwargs):
         DigitalResource.__init__(self, **kwargs)
         self._set_int_prop('index', index, req=True)
@@ -448,7 +431,7 @@ class Reading(DigitalResource):
 
 
 # not a digital resource, just a web endpoint
-class Link(Entity, Targetable):
+class Link(Entity):
     def __init__(self, **kwargs):
         Entity.__init__(self, **kwargs)
 
@@ -505,7 +488,7 @@ class EpubVolume(DigitalResource):
 
 
 ## Annotation entities
-class Annotation(Entity, Generatable):
+class Annotation(Entity):
     def __init__(self, annotated=None, annotator=None, **kwargs):
         Entity.__init__(self, **kwargs)
         self._set_obj_prop('annotated', annotated, t=ENTITY_TYPES['DIGITAL_RESOURCE'], req=True)
@@ -594,7 +577,7 @@ class TextPositionSelector(BaseEntity):
 
 
 ## Assessment entities
-class AssignableDigitalResource(DigitalResource, Assignable):
+class AssignableDigitalResource(DigitalResource):
     def __init__(self,
                  dateToActivate=None,
                  dateToShow=None,
@@ -659,7 +642,7 @@ class AssessmentItem(AssignableDigitalResource):
 
 
 ## Attempt and Response entities
-class Attempt(Entity, Generatable):
+class Attempt(Entity):
     def __init__(self,
                  assignable=None,
                  assignee=None,
@@ -719,7 +702,7 @@ class Attempt(Entity, Generatable):
         return self._get_prop('startedAtTime')
 
 
-class Response(Entity, Generatable):
+class Response(Entity):
     def __init__(self, attempt=None, duration=None, endedAtTime=None, startedAtTime=None,
                  **kwargs):
         Entity.__init__(self, **kwargs)
@@ -877,7 +860,7 @@ class Message(DigitalResource):
 
 
 ## Feedback entities
-class Rating(Entity, Generatable):
+class Rating(Entity):
     def __init__(self,
                  rater=None,
                  rated=None,
@@ -913,7 +896,7 @@ class Rating(Entity, Generatable):
         return self._get_prop('selections')
 
 
-class Comment(Entity, Generatable):
+class Comment(Entity):
     def __init__(self, commenter=None, commentedOn=None, value=None, **kwargs):
         Entity.__init__(self, **kwargs)
         self._set_obj_prop('commenter', commenter, t=ENTITY_TYPES['PERSON'])
@@ -1175,7 +1158,7 @@ class MediaObject(DigitalResource):
         return self._get_prop('duration')
 
 
-class MediaLocation(DigitalResource, Targetable):
+class MediaLocation(DigitalResource):
     def __init__(self, currentTime=None, **kwargs):
         DigitalResource.__init__(self, **kwargs)
         self._set_duration_prop('currentTime', currentTime)
@@ -1221,7 +1204,7 @@ class VideoObject(MediaObject):
 
 
 ## Outcome entities
-class Result(Entity, Generatable):
+class Result(Entity):
     def __init__(self,
                  attempt=None,
                  comment=None,
@@ -1257,7 +1240,7 @@ class Result(Entity, Generatable):
         return self._get_prop('scoredBy')
 
 
-class Score(Entity, Generatable):
+class Score(Entity):
     def __init__(self,
                  attempt=None,
                  comment=None,
@@ -1314,7 +1297,7 @@ class Query(Entity):
         return self._get_prop('searchTerms')
 
 
-class SearchResponse(Entity, Generatable):
+class SearchResponse(Entity):
     def __init__(self,
                  searchProvider=None,
                  searchTarget=None,
@@ -1361,7 +1344,7 @@ class SearchResponse(Entity, Generatable):
 
 
 ## Session entities
-class Session(Entity, Generatable, Targetable):
+class Session(Entity):
     def __init__(self,
                  client=None,
                  duration=None,

--- a/caliper/events.py
+++ b/caliper/events.py
@@ -25,7 +25,7 @@ from future.utils import raise_with_traceback
 from builtins import *
 
 from caliper.constants import CALIPER_ACTIONS, CALIPER_PROFILES
-from caliper.constants import ENTITY_TYPES, EVENT_TYPES, MARKER_TYPES
+from caliper.constants import ENTITY_TYPES, EVENT_TYPES
 from caliper.base import BaseEvent, ensure_type, ensure_types
 
 
@@ -60,12 +60,12 @@ class Event(BaseEvent):
         self._set_obj_prop('edApp', edApp, t=ENTITY_TYPES['SOFTWARE_APPLICATION'])
         self._set_dict_prop('extensions', extensions)
         self._set_obj_prop('federatedSession', federatedSession, t=ENTITY_TYPES['LTI_SESSION'])
-        self._set_obj_prop('generated', generated, t=MARKER_TYPES['GENERATABLE'])
+        self._set_obj_prop('generated', generated)
         self._set_obj_prop('group', group, t=ENTITY_TYPES['ORGANIZATION'])
         self._set_obj_prop('membership', membership, t=ENTITY_TYPES['MEMBERSHIP'])
-        self._set_obj_prop('referrer', referrer, t=MARKER_TYPES['REFERRABLE'])
+        self._set_obj_prop('referrer', referrer)
         self._set_obj_prop('session', session, t=ENTITY_TYPES['SESSION'])
-        self._set_obj_prop('target', target, t=MARKER_TYPES['TARGETABLE'])
+        self._set_obj_prop('target', target)
 
     def as_minimal_event(self):
         return MinimalEvent(id=self.id,


### PR DESCRIPTION
- The marker types aren't in the caliper spec, and so they add complexity without canonicity.

- The dual-inheritance from the marker types causes validation more problems than it solves; we
  should depend only on the validation as required in the Caliper spec.