### PR TITLE
Event object should expose membership accessor

### DIFF
--- a/caliper/events.py
+++ b/caliper/events.py
@@ -127,6 +127,10 @@ class Event(BaseEvent):
         return self._get_prop('referrer')
 
     @property
+    def membership(self):
+        return self._get_prop('membership')
+
+    @property
     def session(self):
         return self._get_prop('session')
 


### PR DESCRIPTION
Seems like all the properties in the constructor should be available through accessors.  (Also, BTW, there's no accessor for sourcedId, but I don't know what it's for: it's ignored in the constructor and not mentioned in the standard)