### PR TITLE
Base entity has no version property

### DIFF
--- a/caliper/entities.py
+++ b/caliper/entities.py
@@ -48,7 +48,6 @@ class Entity(BaseEntity):
         description=None,
         name=None,
         otherIdentifiers=None,
-        version=None,
         extensions=None,
     ):
         BaseEntity.__init__(self, context=context, profile=profile)


### PR DESCRIPTION
Version is a field reserved for SoftwareApplication and DigitalResource (and their subtypes), so
remove keyword arg from the base Entity