### PR TITLE
Rewrote the type-checking statements in sensor.py::Options constructo…

### DIFF
--- a/caliper/events.py
+++ b/caliper/events.py
@@ -343,5 +343,7 @@ class ViewEvent(Event):
                 self.object,
                 [ENTITY_TYPES["QUESTIONNAIRE"], ENTITY_TYPES["QUESTIONNAIRE_ITEM"]],
             )
+        elif self.profile == CALIPER_PROFILES["GRADING"]:
+            ensure_type(self.object, ENTITY_TYPES["RESULT"])
         else:
             ensure_type(self.object, ENTITY_TYPES["DIGITAL_RESOURCE"])

--- a/caliper/sensor.py
+++ b/caliper/sensor.py
@@ -38,22 +38,26 @@ class Client(object):
 
         self._debug = []
 
-        if config_options is None:
-            config_options = Options()
-
-        if config_options and not (isinstance(config_options, Options)):
+        if not config_options:
+            self._config = Options()
+        elif isinstance(config_options, Options):
+            self._config = config_options
+        else:
             raise TypeError("config_options must implement base.Options")
-        self._config = config_options
 
-        if requestor and not (isinstance(requestor, EventStoreRequestor)):
-            raise TypeError("requestor must implement request.EventStoreRequestor")
-        else:
+        if not requestor:
             self._requestor = HttpRequestor(options=self._config)
-
-        if stats and not (isinstance(stats, Statistics)):
-            raise TypeError("stats must implement stats.Stats")
+        elif isinstance(requestor, EventStoreRequestor):
+            self._requestor = requestor
         else:
+            raise TypeError("requestor must implement request.EventStoreRequestor")
+
+        if not stats:
             self._stats = Statistics()
+        elif isinstance(stats, Statistics):
+            self._stats = stats
+        else:
+            raise TypeError("stats must implement stats.Stats")
 
     def _reset(self):
         self._stats = Statistics()
@@ -122,10 +126,10 @@ class SimpleSensor(object):
     def __init__(self, config_options=None, sensor_id=None):
         if not config_options:
             self._config = HttpOptions(optimize_serialization=True)
-        elif not (isinstance(config_options, HttpOptions)):
-            raise TypeError("config_options must implement HttpOptions")
-        else:
+        elif isinstance(config_options, HttpOptions):
             self._config = config_options
+        else:
+            raise TypeError("config_options must implement HttpOptions")
         self._id = sensor_id
         self._requestor = HttpRequestor(options=self._config)
         self._stats = SimpleStatistics()


### PR DESCRIPTION
This PR has two commits:

1. A fix for the Options base class.

In the current code, there is no way to set custom options/requestor/stats. If a valid subclass of the required type is provided, the if statements go to the else code, which sets a hard-coded object rather than the parameter value.

This commit corrects the logic so it only sets the default if the parameter is None.

2.  Allowance for GradingProfile to have a ViewEvent object == Result entity.

The current code doesn't allow for GradingProfile to have a Result entity as its object. In the specification (3.6), it states that this is the correct type of object when sending a ViewEvent under the Grading profile.

This commit adds an `elif` that allows this to be possible.